### PR TITLE
add experimental support for htcondor batch submission

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ from .tools.defs import Status, Type, Theme, Mode
 from .tools import options
 from .tools.wrapper import SingularityWrapper
 from .backends.slurm import Slurm
+from .backends.htcondor import HTCondor
 from .tools.utils import SuccessTrigger, FinishedTrigger, LogMover
 from .tools.profiler import Profiler
 

--- a/backends/defs.py
+++ b/backends/defs.py
@@ -2,4 +2,5 @@
 bids = {
   'BASE': 'Base',
   'SLURM': 'Slurm',
+  'HTCONDOR': 'HTCondor',
 }

--- a/backends/htcondor.py
+++ b/backends/htcondor.py
@@ -1,0 +1,221 @@
+import subprocess
+import os
+import shlex
+import logging
+from ..tools.defs import Status
+from .base import Base
+from .defs import bids
+from ..tools.utils import make_dir, find_between
+log = logging.getLogger('slurmy')
+
+
+class HTCondor(Base):
+    """@SLURMY
+    HTCondor backend class. Inherits from the Base backend class.
+
+    * `name` Name of the parent job.
+    * `log` Output, Error, and Log files written by htcondor.
+    * `run_script` The script that is executed on the worker node.
+    * `run_args` Run arguments that are passed to the run_script.
+
+    HTCondor batch submission arguments (see slurm documentation):
+
+    * `mem` Memory limit for the slurm job.
+    * `time` Time limit for the slurm job.
+    * `export` Environment exports that are propagated to the slurm job.
+    """
+    
+    bid = bids['HTCONDOR']
+    _commands = ['condor_submit', 'condor_rm', 'condor_history', 'condor_q']
+    _successcode = '0'
+    _run_states = set([1, 2])  # 1: IDLE, 2: RUNNING
+    
+    def __init__(self, name = None, log = None, run_script = None, run_args = None, mem = None, time = None, export = None):
+        super(HTCondor, self).__init__()
+        ## Common backend options
+        self.name = name
+        self.log = log
+        self.run_script = run_script
+        self.run_args = run_args
+        ## Batch options
+        self.mem = mem
+        self.time = time
+        self.export = export
+        ## Internal variables
+        self._job_id = {}
+        self._exitcode = None
+
+
+    def _writeSubmissionFile(self, script_folder):
+        """@SLURMY
+        Write submission file required for HTCondor to disk.
+
+        Returns the path to the submission file
+        """
+        submissionfile_path = os.path.join(script_folder, "{job}.sub".format(job=self.name))
+
+        log.debug('({}) Writing submission file to {}'.format(self.name, script_folder))
+        with open(submissionfile_path, 'w') as f:
+            f.write("""universe                = vanilla
+executable              = {executable}
+output                  = {logdir}/{name}.$(ClusterId).$(Process).out
+error                   = {logdir}/{name}.$(ClusterId).$(Process).err
+log                     = {logdir}/{name}.$(ClusterId).$(Process).log
+
+transfer_executable     = True
+
+request_cpus            = {nproc}
+{runtime}
+{memory}
+
+queue
+            """.format(
+                    executable=self.wrapper.get(self.run_script),  # Get run_script setup through wrapper
+                    logdir=os.path.abspath(os.path.join(script_folder, os.pardir, 'logs')),
+                    name=self.name,
+                    nproc="1",
+                    runtime="+RequestRuntime         = {runtime}".format(runtime=self.time) if self.time else "",
+                    memory="RequestMemory           = {memory}".format(memory=self.mem) if self.mem else ""
+                ))
+        return submissionfile_path
+
+
+    def write_script(self, script_folder):
+        """@SLURMY
+        Write the run_script according to configuration.
+        Do everything that is done in base class and in addition add HTCondor submission file
+
+        * `script_folder` Folder to store the script file in.
+        """
+        super(HTCondor, self).write_script(script_folder)
+        submission_file = self._writeSubmissionFile(script_folder)
+
+
+    def submit(self):
+        """@SLURMY
+        Submit the job to the HTCondor batch system.
+        Adds the job id (int) and the absolute path to the log file to this class
+        Returns the job id (int).
+        """
+        submit_list = ['condor_submit', '-verbose']
+
+        ## shlex splits run_script in a Popen digestable way
+        submissionfile = self.run_script + '.sub'
+        submissionfile = shlex.split(submissionfile)
+        submit_list += submissionfile
+
+        if self.run_args:
+            log.info('({}) Run arguments are not yet supported. Won\'t consider {}'.format(self.name, self.run_args))
+            
+        log.debug('({}) Submit job with command {}'.format(self.name, submit_list))
+        submit_string = subprocess.check_output(submit_list, universal_newlines = True)
+        job_id = find_between(submit_string, '** Proc ', ':')
+        job_log = find_between(submit_string, 'UserLog = "', '"')
+        self._job_id[job_id] = job_log
+        return job_id
+
+    def cancel(self):
+        """@SLURMY
+        Cancel the slurm job.
+        """
+        log.debug('({}) Cancel job'.format(self.name))
+        os.system('condor_rm {}'.format(" ".join(self._job_id.keys())))
+
+
+    def _get_job_info(self):
+        """ @SLURMY
+        Get information about job from log file.
+        By using local log files to get information about job status, the load on the HTCondor schedd is reduced.
+        Information about job status can be found here: http://pages.cs.wisc.edu/~adesmet/status.html
+
+        """
+        command = ['condor_history']
+        command.extend(['-autoformat', 'ClusterId', 'JobStatus', 'ExitCode'])
+        command.extend(['-userlog', ''])  # path to user log needs to be swapped
+        for jobid, logpath in self._job_id.items():
+            command[-1] = logpath
+            condor_history_list = subprocess.check_output(command, universal_newlines = True).rstrip('\n').split('\n')
+            log.debug('({}) Return list for job id {} from condor_history: {}'.format(self.name, jobid, condor_history_list))
+            condor_history_return = None
+            if len(condor_history_list) > 0:
+                condor_history_return = {}
+                for entry in condor_history_list:
+                    job_id, state, exitcode = entry.split()
+                    log.debug('({}) Values from condor_history: {} {} {}'.format(self.name, job_id, state, exitcode))
+                    condor_history_return['finished'] = state
+                    if exitcode != 'undefined':
+                        condor_history_return['success'] = exitcode
+                    elif state in ('3', '5', '6') :  # state 3: job removed, state 5: job help, state 6: submission error
+                        condor_history_return['success'] = 1
+
+        return condor_history_return
+
+    def status(self):
+        """@SLURMY
+        Get the status of slurm job from htcondor job log file (to reduce load on scheduler).
+
+        Returns the job status (Status).
+        """
+        jobinfo = self._get_job_info()
+
+        status = Status.RUNNING
+        if jobinfo is not None:
+            job_state = jobinfo['finished']
+            if job_state not in HTCondor._run_states and 'success' in jobinfo:
+                status = Status.FINISHED
+                self._exitcode = jobinfo['success']
+
+        return status
+
+    def exitcode(self):
+        """@SLURMY
+        Get the exitcode of slurm job from htcondor job log file. Evaluation is actually done by HTCondor.status(), HTCondor.exitcode() only returns the value. If exitcode at this stage is None, execute HTCondor.status() beforehand.
+
+        Returns the job exitcode (str).
+        """
+        ## If exitcode is not set yet, run status evaluation
+        if self._exitcode is None:
+            self.status()
+            
+        return self._exitcode
+
+    @staticmethod
+    def get_listen_func():
+        """@SLURMY
+        Listener function, will be added to listener instance.
+        Limited functionality, updating of jobs not fully functional at the moment.
+
+        It is recommended to use a "non-listening" JobHandler when using HTCondor.
+        Example how to set up a job handler for HTCondor: jh = JobHandler(backend=HTCondor(), listens=False)
+
+        Returns listen function.
+        """
+
+        command = ['condor_q']
+        user = os.environ['USER']
+        command.extend(['-autoformat', 'ClusterId', 'JobStatus', '-constraint', 'owner == "{}"'.format(user)])
+        ## Define function for Listener
+        def listen(results, interval = 1):
+            import subprocess, time
+            from collections import OrderedDict
+            job_ids = set()
+            while True:
+                result = subprocess.check_output(command, universal_newlines = True).rstrip('\n').split('\n')
+                unfinished_job_ids = set()
+                for res in result:
+                    if not res: continue
+                    job_id, state = res.split()
+                    print(job_id, state)
+                    job_ids.add(job_id)
+                    unfinished_job_ids.add(job_id)
+                ## Generate results dict
+                res_dict = OrderedDict()
+                for job_id in job_ids:
+                    if job_id not in unfinished_job_ids:
+                        exitcode_cmd = ['condor_history', '-autoformat', 'ExitCode', '-constraint', 'ClusterId == {}'.format(job_id)]
+                        exitcode = subprocess.check_output(exitcode_cmd, universal_newlines = True).rstrip('\n')
+                        res_dict[int(job_id)] = {'status': Status.FINISHED, 'exitcode': int(exitcode)}
+                results.put(res_dict)
+                time.sleep(interval)
+
+        return listen

--- a/backends/htcondor.py
+++ b/backends/htcondor.py
@@ -46,7 +46,7 @@ class HTCondor(Base):
         self._exitcode = None
 
 
-    def _writeSubmissionFile(self, script_folder):
+    def _write_submissionfile(self, script_folder):
         """@SLURMY
         Write submission file required for HTCondor to disk.
 
@@ -88,7 +88,7 @@ queue
         * `script_folder` Folder to store the script file in.
         """
         super(HTCondor, self).write_script(script_folder)
-        submission_file = self._writeSubmissionFile(script_folder)
+        submission_file = self._write_submissionfile(script_folder)
 
 
     def submit(self):

--- a/backends/utils.py
+++ b/backends/utils.py
@@ -7,8 +7,10 @@ backend_list = set([l[1] for l in bids.items() if l[0] != 'BASE'])
 def get_backend(bid):
     import logging
     from .slurm import Slurm
+    from .htcondor import HTCondor
     log = logging.getLogger('slurmy')
     if bid == bids['SLURM']: return Slurm()
+    elif bid == bids['HTCONDOR']: return HTCondor()
     else:
         log.error('Unknown backend "{}"'.format(bid))
         return None

--- a/tools/jobhandler.py
+++ b/tools/jobhandler.py
@@ -381,10 +381,17 @@ class JobHandler(object):
         ## TODO: In interactive slurmy, test_mode activation is not triggered unless a Slurm instance is created --> Listener is setup even though Slurm doesn't work
         if not options.Main.test_mode:
             from ..backends.slurm import Slurm
-            ## This one also sets the exitcode of the job, so the success evaluation can be done by itself.
-            listen_slurm = Slurm.get_listen_func()
-            listener_slurm = Listener(self, listen_slurm, Status.RUNNING, 'id')
-            listeners.append(listener_slurm)
+            from ..backends.htcondor import HTCondor
+            if isinstance(self.config.backend, Slurm):
+                ## This one also sets the exitcode of the job, so the success evaluation can be done by itself.
+                listen_slurm = Slurm.get_listen_func()
+                listener_slurm = Listener(self, listen_slurm, Status.RUNNING, 'id')
+                listeners.append(listener_slurm)
+            elif isinstance(self.config.backend, HTCondor):
+                listen_htcondor = HTCondor.get_listen_func()
+                listener_htcondor = Listener(self, listen_htcondor, Status.RUNNING, 'id')
+                listeners.append(listener_htcondor)
+            
         ## Get list of defined output files
         file_list = [l.output for l in self.jobs.values() if l.output is not None]
         ## Set up output file listener, if any are defined

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,4 +1,4 @@
-\
+import re
 import logging
 log = logging.getLogger('slurmy')
 
@@ -257,11 +257,10 @@ def remove_content(folder):
 
 ## String manipulation utils
 def find_between(s, first, last):
-    """Find substring between two substrings first and last in string s."""
+    """Find first substring between two substrings first and last in string s."""
     try:
-        start = s.index(first) + len(first)
-        end = s.index(last, start)
-        return s[start:end]
+        expression = '{}(.+?){}'.format(first, last)
+        return re.findall(expression, s)[0]
     except ValueError:
         logging.error("String `{s}` does not contain a substring between `{first}` and `{last}`".format(s=s, first=first, last=last))
         return ""

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -258,9 +258,10 @@ def remove_content(folder):
 ## String manipulation utils
 def find_between(s, first, last):
     """Find first substring between two substrings first and last in string s."""
-    try:
-        expression = '{}(.+?){}'.format(first, last)
-        return re.findall(expression, s)[0]
-    except ValueError:
-        logging.error("String `{s}` does not contain a substring between `{first}` and `{last}`".format(s=s, first=first, last=last))
-        return ""
+    expression = '{}(.+?){}'.format(first, last)
+    results = re.findall(expression, s)
+    if len(results) == 0:
+        log.error('Could not find substring in "{s}" between "{first}" and "{last}"'.format(s=s, first=first, last=last))
+        return ''
+    else:
+        return results[0]

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -254,3 +254,14 @@ def remove_content(folder):
     import os, glob
     for file_name in glob.glob(os.path.join(folder, '*')):
         os.remove(file_name)
+
+## String manipulation utils
+def find_between(s, first, last):
+    """Find substring between two substrings first and last in string s."""
+    try:
+        start = s.index(first) + len(first)
+        end = s.index(last, start)
+        return s[start:end]
+    except ValueError:
+        logging.error("String `{s}` does not contain a substring between `{first}` and `{last}`".format(s=s, first=first, last=last))
+        return ""


### PR DESCRIPTION
Dear Thomas Maier,

this pull request tries to add experimental support for the HTCondor batch engine.
It does not affect the slurm submission to my best testing and knowledge.

The HTCondor support is e.g. very useful to have when working on CERN's lxplus or DESY's NAF. Those sites do not support slurm or do so only in very limited amount.

## What this pull request does

The pull request adds experimental support for HTCondor batch engines.

Minimal example:
```
from slurmy import JobHandler, Theme, Type, Slurm, HTCondor
# Set up backend for job submission
backend = HTCondor()
# Set up the JobHandler
jh = JobHandler(backend=backend, listens=False)
run_script = """
echo "hans"
"""
# define backend for job (required if user wants to submit multiple jobs)
backend_job = getBackend(args.backend)
jh.add_job(run_script = run_script, backend = backend_job)

# Run all jobs
jh.run_jobs()
```

## Shortcomings

1. However the HTCondor support is not as fully functional as the SLURM support.
Right now the listener support for HTCondor is not working optimally. Once a job finishes the listener does register the modified job state but does not update the status bar.
The submission works flawless however if one decides not to use a listener. This also strongly reduces the load on the HTCondor job scheduler and on other user's performance.

2. Right now in order to submit multiple jobs the user has to define a backend for each single job. Otherwise if he or she defines *n* jobs and uses the same backend with `add_job` for all of them, then the scripts and submission files for all *n* jobs are created but only the last created job is submitted *n* times. 
